### PR TITLE
Make Imbue backend and Firebase auth conditional at build time

### DIFF
--- a/Bouncer/build.js
+++ b/Bouncer/build.js
@@ -14,6 +14,9 @@ const ENV_KEYS = [
   'GOOGLE_CLIENT_ID', 'IMBUE_WS_URL',
 ];
 
+// Keys required for the Imbue backend (all env keys except BOUNCER_ENV)
+const IMBUE_KEYS = ENV_KEYS.filter(k => k !== 'BOUNCER_ENV');
+
 function loadEnvFile(envName) {
   const envPath = path.join(__dirname, `.env.${envName}`);
   const result = { BOUNCER_ENV: envName };
@@ -28,8 +31,6 @@ function loadEnvFile(envName) {
       if (eqIndex === -1) continue;
       result[trimmed.slice(0, eqIndex).trim()] = trimmed.slice(eqIndex + 1).trim();
     }
-  } else {
-    console.warn(`Warning: ${envPath} not found. Copy .env.example to .env.${envName} and fill in your values.`);
   }
 
   // Allow process.env overrides (for CI or Docker)
@@ -41,20 +42,50 @@ function loadEnvFile(envName) {
   return result;
 }
 
+// Check if all Imbue-specific env vars have non-empty values
+function checkImbueConfigured(config) {
+  return IMBUE_KEYS.every(key => config[key] && config[key].length > 0);
+}
+
 const config = loadEnvFile(env);
+const hasImbue = checkImbueConfigured(config);
 
 // Build esbuild define map — replaces process.env.X with literal strings
 const define = {
   'process.env.NODE_ENV': '"production"',
+  'process.env.HAS_IMBUE_BACKEND': JSON.stringify(String(hasImbue)),
 };
 for (const [key, value] of Object.entries(config)) {
   define[`process.env.${key}`] = JSON.stringify(value);
 }
 
+// When Imbue is not configured, swap auth.ts and ws-manager.ts with no-op stubs
+// so the Firebase SDK and WebSocket code are completely excluded from the bundle.
+const imbueStubPlugin = {
+  name: 'imbue-stub',
+  setup(build) {
+    // Match relative imports of ./auth and ./ws-manager from background/
+    build.onResolve({ filter: /^\.\/auth$/ }, (args) => {
+      if (args.importer.includes(path.join('src', 'background'))) {
+        return { path: path.join(__dirname, 'src', 'background', 'auth.stub.ts') };
+      }
+    });
+    build.onResolve({ filter: /^\.\/ws-manager$/ }, (args) => {
+      if (args.importer.includes(path.join('src', 'background'))) {
+        return { path: path.join(__dirname, 'src', 'background', 'ws-manager.stub.ts') };
+      }
+    });
+  },
+};
+
 const adapterTsPath = path.join(__dirname, 'adapters/twitter/TwitterAdapter.ts');
 const hasAdapterTs = fs.existsSync(adapterTsPath);
 
 async function build() {
+  console.log(hasImbue
+    ? `Building with Imbue backend (env: ${env})`
+    : `Building without Imbue backend (no .env.${env} configured with Imbue keys)`);
+
   // Bundle main entry points (background, popup, content)
   const ctx = await esbuild.context({
     entryPoints: [
@@ -71,6 +102,7 @@ async function build() {
     sourcemap: false,
     external: ['url'],
     define,
+    plugins: hasImbue ? [] : [imbueStubPlugin],
   });
 
   const contexts = [ctx];

--- a/Bouncer/popup.html
+++ b/Bouncer/popup.html
@@ -91,7 +91,7 @@
       <!-- OpenRouter OAuth -->
       <div class="api-provider" id="openrouterProvider">
         <div class="api-provider-header" data-provider="openrouter">
-          <span class="api-provider-name">OpenRouter (recommended)</span>
+          <span class="api-provider-name">OpenRouter</span>
           <div class="api-provider-header-right">
             <span id="openrouterStatusBadge" class="api-status-badge">Not enabled</span>
             <span class="api-provider-arrow">&#9662;</span>

--- a/Bouncer/popup.html
+++ b/Bouncer/popup.html
@@ -38,7 +38,7 @@
       <label>Choose a model</label>
       <div class="model-dropdown" id="modelDropdown">
         <div class="model-dropdown-selected" id="modelDropdownSelected">
-          <span class="model-dropdown-text">Imbue (Default)</span>
+          <span class="model-dropdown-text">Select a model</span>
           <span class="model-dropdown-arrow">&#9662;</span>
         </div>
         <div class="model-dropdown-menu" id="modelDropdownMenu">

--- a/Bouncer/src/background/auth.stub.ts
+++ b/Bouncer/src/background/auth.stub.ts
@@ -1,0 +1,14 @@
+// Stub: auth not available (no Imbue backend configured at build time)
+// Matches the export interface of auth.ts so all imports compile unchanged.
+
+export function getAuthToken(): Promise<string | null> {
+  return Promise.resolve(null);
+}
+
+export function launchAuthFlow(): Promise<string | null> {
+  return Promise.resolve(null);
+}
+
+export function refreshAuthToken(): Promise<string | null> {
+  return Promise.resolve(null);
+}

--- a/Bouncer/src/background/index.ts
+++ b/Bouncer/src/background/index.ts
@@ -84,7 +84,9 @@ if (chrome.runtime.setUninstallURL) {
 (async () => {
   try {
     await loadCache();
-    await refreshAuthToken();
+    if (process.env.HAS_IMBUE_BACKEND === 'true') {
+      await refreshAuthToken();
+    }
     // Wire up pipeline with shared state
     initPipeline(activeContentTabs);
     await localEngine.syncAllStatuses();
@@ -326,11 +328,17 @@ async function handleMessage(
     }
 
     case 'getAuthStatus': {
+      if (process.env.HAS_IMBUE_BACKEND !== 'true') {
+        return { authenticated: true };
+      }
       const token = await getAuthToken();
       return { authenticated: !!token };
     }
 
     case 'launchGoogleAuth': {
+      if (process.env.HAS_IMBUE_BACKEND !== 'true') {
+        return { success: false, error: 'Not available' };
+      }
       try {
         const token = await launchAuthFlow();
         if (token) {

--- a/Bouncer/src/background/pipeline.ts
+++ b/Bouncer/src/background/pipeline.ts
@@ -19,6 +19,8 @@ import type {
 
 // ==================== Constants ====================
 
+export const DEFAULT_MODEL = process.env.HAS_IMBUE_BACKEND === 'true' ? 'imbue' : '';
+
 const CACHE_SIZE = 500; // Increased for persistent storage
 const BATCH_DELAY_MS = 1000; // Wait time to collect posts before sending batch
 const MAX_CONCURRENT_BATCHES = 100; // Allow parallel batch processing
@@ -185,7 +187,7 @@ export async function getSettings(siteId?: SiteId): Promise<Settings> {
     enabled: data.enabled !== false,
     descriptions,
     useEmbeddings: data.useEmbeddings || false,
-    selectedModel: data.selectedModel || 'imbue',
+    selectedModel: data.selectedModel || DEFAULT_MODEL,
     customModels: data.customModels || [],
     predefinedModelKwargs: data.predefinedModelKwargs || {}
   };
@@ -509,6 +511,14 @@ async function processBatch(): Promise<void> {
     return;
   }
 
+  // Check if a model is configured
+  if (!settings.selectedModel) {
+    const noModelError: PipelineError = { error: 'no_api_key', reasoning: 'No model configured. Open Bouncer settings to choose a model.' };
+    resolveWithDuplicates(batchTabId, item, noModelError);
+    inFlightBatches--;
+    return;
+  }
+
   // Check cache
   const imageUrls = item.imageUrls || [];
   const cacheKey = generateCacheKey(item.post, imageUrls);
@@ -526,7 +536,7 @@ async function processBatch(): Promise<void> {
   // Build API config
   let apiConfig: APIConfig;
 
-  if (settings.selectedModel === 'imbue') {
+  if (process.env.HAS_IMBUE_BACKEND === 'true' && settings.selectedModel === 'imbue') {
     apiConfig = { modelName: 'imbue', apiName: 'imbue', apiKey: null };
   } else if (isLocalModel) {
     const modelName = settings.selectedModel.split(':')[1];
@@ -781,7 +791,7 @@ async function validateFilterPhrase(postText: string, imageUrls: string[], phras
   const postData = { text: postText, imageUrls: imageUrls || [] };
   const isLocalModel = settings.selectedModel?.startsWith('local:');
 
-  if (settings.selectedModel === 'imbue') {
+  if (process.env.HAS_IMBUE_BACKEND === 'true' && settings.selectedModel === 'imbue') {
     const authToken = await getAuthToken();
     const imbueResponse = await callImbueAPI(postData, [phrase], 'validatePhrase', authToken);
     return imbueResponse.shouldHide === true;
@@ -819,7 +829,7 @@ async function generateCandidatePhrases(postText: string, imageUrls: string[], c
   const simpleSystemPrompt = `Given a social media post, suggest exactly ${count} broad content category labels (1-3 words each) that someone might want to filter out because the post is annoying, obnoxious, or unpleasant. Each label must be a general topic or content type such that if another model were asked "does this post relate to [label]?", it would say yes. Focus on what makes the post grating or unwelcome. At least one of the ${count} labels MUST describe a negative emotional tone or off-putting quality of the post. ${imageNote}${rejected} Output ONLY the ${count} category labels, one per line, nothing else.`;
   let result: string[];
 
-  if (settings.selectedModel === 'imbue') {
+  if (process.env.HAS_IMBUE_BACKEND === 'true' && settings.selectedModel === 'imbue') {
     const postData = { text: postText, imageUrls: imageUrls || [] };
     const authToken = await getAuthToken();
     const imbueResponse = await callImbueAPI(postData, undefined, 'suggestAnnoying', authToken);

--- a/Bouncer/src/background/pipeline.ts
+++ b/Bouncer/src/background/pipeline.ts
@@ -5,7 +5,7 @@ import {
   parseAPIResponse, checkRateLimitError, checkApiError, checkAuthenticationError,
   RATE_LIMIT_TYPE_CONFIG, API_ERROR_TYPE_CONFIG,
 } from '../shared/utils';
-import { PREDEFINED_MODELS, API_DISPLAY_NAMES } from '../shared/models';
+import { PREDEFINED_MODELS, API_DISPLAY_NAMES, DEFAULT_MODEL } from '../shared/models';
 import { buildAPIMessages } from '../shared/prompts';
 import { callDirectAPI, callAnthropicAPI, callImbueAPI } from './providers';
 import { callLocalInference, localEngine } from './local-model';
@@ -18,8 +18,6 @@ import type {
 } from '../types';
 
 // ==================== Constants ====================
-
-export const DEFAULT_MODEL = process.env.HAS_IMBUE_BACKEND === 'true' ? 'imbue' : '';
 
 const CACHE_SIZE = 500; // Increased for persistent storage
 const BATCH_DELAY_MS = 1000; // Wait time to collect posts before sending batch

--- a/Bouncer/src/background/providers.ts
+++ b/Bouncer/src/background/providers.ts
@@ -176,6 +176,9 @@ export async function callImbueAPI(
   reason: string,
   authToken?: string | null
 ): Promise<ImbueFilterResponse | ImbueSuggestResponse> {
+  if (process.env.HAS_IMBUE_BACKEND !== 'true') {
+    throw new Error('Imbue backend not configured');
+  }
   const message: Record<string, unknown> = {
     action: "tweetFilter",
     tweetData: tweetData,
@@ -204,6 +207,7 @@ interface FeedbackMessage {
 
 // Send feedback (false_positive / false_negative) to Imbue via persistent WebSocket
 export async function sendFeedback(feedbackMessage: FeedbackMessage, authToken?: string | null): Promise<void> {
+  if (process.env.HAS_IMBUE_BACKEND !== 'true') return;
   if (authToken) {
     feedbackMessage.authToken = authToken;
   }

--- a/Bouncer/src/background/ws-manager.stub.ts
+++ b/Bouncer/src/background/ws-manager.stub.ts
@@ -1,0 +1,21 @@
+// Stub: WebSocket manager not available (no Imbue backend configured at build time)
+// Matches the export interface of ws-manager.ts so all imports compile unchanged.
+
+import type { ImbueAPIResponse } from '../types';
+
+export const imbueWebSocket = {
+  ws: null as WebSocket | null,
+  connectPromise: null as Promise<WebSocket> | null,
+  unackedRequests: new Map(),
+  pendingRequests: new Map(),
+
+  disconnect(): void {},
+
+  send(_message: Record<string, unknown>): Promise<ImbueAPIResponse> {
+    return Promise.reject(new Error('Imbue backend not configured'));
+  },
+
+  sendFireAndForget(_message: object): Promise<void> {
+    return Promise.resolve();
+  },
+};

--- a/Bouncer/src/content/index.ts
+++ b/Bouncer/src/content/index.ts
@@ -2,6 +2,7 @@
 // Entry point: post processing, observers, init, storage/message listeners
 
 import type { PlatformAdapter, PostContent, PipelineResponse, BackgroundToContentMessage, DescriptionKey } from '../types';
+import { DEFAULT_MODEL } from '../shared/models';
 import { getStorage, removeStorage, getDescriptions, setDescriptions } from '../shared/storage';
 
 import {
@@ -122,8 +123,7 @@ import { formatPostForEvaluation } from '../shared/utils';
   async function checkLocalModelActive() {
     try {
       const data = await getStorage(['selectedModel']);
-      const defaultModel = process.env.HAS_IMBUE_BACKEND === 'true' ? 'imbue' : '';
-      const model = data.selectedModel || defaultModel;
+      const model = data.selectedModel || DEFAULT_MODEL;
       isLocalModelActive = model.startsWith('local:');
       // Keep latency alert state in sync so the viewport-based latency check
       // knows which model is active before any latencyUpdate message arrives.
@@ -494,8 +494,7 @@ import { formatPostForEvaluation } from '../shared/utils';
         }
       }
       if (changes.selectedModel) {
-        const defaultModel = process.env.HAS_IMBUE_BACKEND === 'true' ? 'imbue' : '';
-        const newModel = (changes.selectedModel.newValue as string) || defaultModel;
+        const newModel = (changes.selectedModel.newValue as string) || DEFAULT_MODEL;
         isLocalModelActive = newModel.startsWith('local:') || false;
         updateAlertState('latency', { isHighLatency: false, medianLatency: 0, selectedModel: newModel, hasAlternativeApis: false });
         updateAlertState('error', { type: null, subType: null, count: 0, apiDisplayName: null, selectedModel: newModel, hasAlternativeApis: false });

--- a/Bouncer/src/content/index.ts
+++ b/Bouncer/src/content/index.ts
@@ -122,7 +122,8 @@ import { formatPostForEvaluation } from '../shared/utils';
   async function checkLocalModelActive() {
     try {
       const data = await getStorage(['selectedModel']);
-      const model = data.selectedModel || 'imbue';
+      const defaultModel = process.env.HAS_IMBUE_BACKEND === 'true' ? 'imbue' : '';
+      const model = data.selectedModel || defaultModel;
       isLocalModelActive = model.startsWith('local:');
       // Keep latency alert state in sync so the viewport-based latency check
       // knows which model is active before any latencyUpdate message arrives.
@@ -493,7 +494,8 @@ import { formatPostForEvaluation } from '../shared/utils';
         }
       }
       if (changes.selectedModel) {
-        const newModel = (changes.selectedModel.newValue as string) || 'imbue';
+        const defaultModel = process.env.HAS_IMBUE_BACKEND === 'true' ? 'imbue' : '';
+        const newModel = (changes.selectedModel.newValue as string) || defaultModel;
         isLocalModelActive = newModel.startsWith('local:') || false;
         updateAlertState('latency', { isHighLatency: false, medianLatency: 0, selectedModel: newModel, hasAlternativeApis: false });
         updateAlertState('error', { type: null, subType: null, count: 0, apiDisplayName: null, selectedModel: newModel, hasAlternativeApis: false });

--- a/Bouncer/src/content/ui.ts
+++ b/Bouncer/src/content/ui.ts
@@ -12,15 +12,17 @@ let _deps: ContentUIDeps;
 export function initUI(deps: ContentUIDeps) {
   _deps = deps;
 
-  // Listen for auth state changes from background
-  chrome.runtime.onMessage.addListener((message: BackgroundToContentMessage) => {
-    if (message.type === 'authStateChanged') {
-      isAuthenticated = message.authenticated;
-      if (isAuthenticated) {
-        refreshAllFilterBoxes();
+  // Listen for auth state changes from background (only when Imbue backend is configured)
+  if (process.env.HAS_IMBUE_BACKEND === 'true') {
+    chrome.runtime.onMessage.addListener((message: BackgroundToContentMessage) => {
+      if (message.type === 'authStateChanged') {
+        isAuthenticated = message.authenticated;
+        if (isAuthenticated) {
+          refreshAllFilterBoxes();
+        }
       }
-    }
-  });
+    });
+  }
 }
 
 // Must be called before injecting filter boxes
@@ -47,9 +49,10 @@ let toastContainer: HTMLElement | null = null;
 const annoyingReasonsCache: WeakMap<HTMLElement, Promise<{ reasons: string[]; hadImages?: boolean }>> = new WeakMap();
 
 // Unified alert state
+const defaultModel = process.env.HAS_IMBUE_BACKEND === 'true' ? 'imbue' : '';
 export const alertState: AlertState = {
-  latency: { isHighLatency: false, medianLatency: 0, selectedModel: 'imbue', hasAlternativeApis: false },
-  error: { type: null, subType: null, count: 0, apiDisplayName: null, selectedModel: 'imbue', hasAlternativeApis: false },
+  latency: { isHighLatency: false, medianLatency: 0, selectedModel: defaultModel, hasAlternativeApis: false },
+  error: { type: null, subType: null, count: 0, apiDisplayName: null, selectedModel: defaultModel, hasAlternativeApis: false },
   queue_backlog: { pendingCount: 0, isLocalModel: false, modelInitializing: false }
 };
 
@@ -63,10 +66,15 @@ let apiKeyWarningShown = false;
 
 // ==================== Auth State ====================
 
-let isAuthenticated = false;
+// When no Imbue backend, skip auth entirely — users are always "authenticated"
+let isAuthenticated = process.env.HAS_IMBUE_BACKEND !== 'true';
 
 // Check auth status from background and cache it
 async function checkAuthStatus() {
+  if (process.env.HAS_IMBUE_BACKEND !== 'true') {
+    isAuthenticated = true;
+    return true;
+  }
   try {
     const response: { authenticated?: boolean } = await chrome.runtime.sendMessage({ type: 'getAuthStatus' });
     isAuthenticated = response?.authenticated ?? false;
@@ -1602,7 +1610,7 @@ export function showApiKeyWarning() {
       <span class="toast-title">Feed Filter</span>
       <button class="toast-close">&times;</button>
     </div>
-    <div class="toast-content">No API key configured. Click the extension icon to add your Claude API key.</div>
+    <div class="toast-content">No model configured. Open Bouncer settings to choose a model.</div>
   `;
   container.appendChild(toast);
   requestAnimationFrame(() => toast.classList.add('toast-visible'));

--- a/Bouncer/src/content/ui.ts
+++ b/Bouncer/src/content/ui.ts
@@ -2,6 +2,7 @@
 
 import { ALERT_CONFIG } from '../shared/alerts';
 import { asyncHandler } from '../shared/async';
+import { DEFAULT_MODEL } from '../shared/models';
 import { cleanReasoning, escapeHtml, formatPostForEvaluation } from '../shared/utils';
 import type { AlertState, BackgroundToContentMessage, ContentUIDeps, FilteredPost, PostContent, AlertDisplayConfig, LocalModelStatus } from '../types';
 import { getStorage, getDescriptions, setDescriptions } from '../shared/storage';
@@ -49,10 +50,9 @@ let toastContainer: HTMLElement | null = null;
 const annoyingReasonsCache: WeakMap<HTMLElement, Promise<{ reasons: string[]; hadImages?: boolean }>> = new WeakMap();
 
 // Unified alert state
-const defaultModel = process.env.HAS_IMBUE_BACKEND === 'true' ? 'imbue' : '';
 export const alertState: AlertState = {
-  latency: { isHighLatency: false, medianLatency: 0, selectedModel: defaultModel, hasAlternativeApis: false },
-  error: { type: null, subType: null, count: 0, apiDisplayName: null, selectedModel: defaultModel, hasAlternativeApis: false },
+  latency: { isHighLatency: false, medianLatency: 0, selectedModel: DEFAULT_MODEL, hasAlternativeApis: false },
+  error: { type: null, subType: null, count: 0, apiDisplayName: null, selectedModel: DEFAULT_MODEL, hasAlternativeApis: false },
   queue_backlog: { pendingCount: 0, isLocalModel: false, modelInitializing: false }
 };
 

--- a/Bouncer/src/content/ui.ts
+++ b/Bouncer/src/content/ui.ts
@@ -1607,7 +1607,7 @@ export function showApiKeyWarning() {
   toast.className = 'post-filter-toast post-filter-warning';
   toast.innerHTML = `
     <div class="toast-header">
-      <span class="toast-title">Feed Filter</span>
+      <span class="toast-title">Bouncer</span>
       <button class="toast-close">&times;</button>
     </div>
     <div class="toast-content">No model configured. Open Bouncer settings to choose a model.</div>

--- a/Bouncer/src/popup/index.ts
+++ b/Bouncer/src/popup/index.ts
@@ -1,7 +1,7 @@
 // Bouncer - Popup Script
 
 import type { ModelDef, LocalModelStatus, StorageSchema } from '../types';
-import { PREDEFINED_MODELS } from '../shared/models';
+import { PREDEFINED_MODELS, DEFAULT_MODEL } from '../shared/models';
 import { escapeHtml } from '../shared/utils';
 import { getStorage, setStorage, removeStorage } from '../shared/storage';
 import { asyncHandler } from '../shared/async';
@@ -9,8 +9,6 @@ import { asyncHandler } from '../shared/async';
 // Storage key for predefined model API kwargs overrides
 // Format: { "api:modelName": { key: value, ... }, ... }
 let predefinedModelKwargs: Record<string, Record<string, unknown>> = {};
-
-const DEFAULT_MODEL = process.env.HAS_IMBUE_BACKEND === 'true' ? 'imbue' : '';
 
 const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   ...(process.env.HAS_IMBUE_BACKEND === 'true' ? { imbue: 'Imbue (Default)' } : {}),

--- a/Bouncer/src/popup/index.ts
+++ b/Bouncer/src/popup/index.ts
@@ -10,8 +10,10 @@ import { asyncHandler } from '../shared/async';
 // Format: { "api:modelName": { key: value, ... }, ... }
 let predefinedModelKwargs: Record<string, Record<string, unknown>> = {};
 
+const DEFAULT_MODEL = process.env.HAS_IMBUE_BACKEND === 'true' ? 'imbue' : '';
+
 const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
-  imbue: 'Imbue (Default)',
+  ...(process.env.HAS_IMBUE_BACKEND === 'true' ? { imbue: 'Imbue (Default)' } : {}),
   local: 'Local',
   openrouter: 'OpenRouter',
   openai: 'OpenAI',
@@ -125,36 +127,38 @@ async function init() {
     sendSize();
   }
 
-  // Check auth status and show appropriate screen
-  const signinContainer = document.getElementById('signinContainer');
-  const mainContainer = document.getElementById('mainContainer');
-  const popupGoogleSignIn = document.getElementById('popupGoogleSignIn');
-  try {
-    const authResponse: { authenticated?: boolean } = await chrome.runtime.sendMessage({ type: 'getAuthStatus' });
-    if (!authResponse?.authenticated) {
-      if (signinContainer) signinContainer.style.display = '';
-      if (mainContainer) mainContainer.style.display = 'none';
+  // Check auth status and show appropriate screen (only when Imbue backend is configured)
+  if (process.env.HAS_IMBUE_BACKEND === 'true') {
+    const signinContainer = document.getElementById('signinContainer');
+    const mainContainer = document.getElementById('mainContainer');
+    const popupGoogleSignIn = document.getElementById('popupGoogleSignIn');
+    try {
+      const authResponse: { authenticated?: boolean } = await chrome.runtime.sendMessage({ type: 'getAuthStatus' });
+      if (!authResponse?.authenticated) {
+        if (signinContainer) signinContainer.style.display = '';
+        if (mainContainer) mainContainer.style.display = 'none';
 
-      // Wire up sign-in button
-      popupGoogleSignIn?.addEventListener('click', () => { (async () => {
-        const result: { success?: boolean } = await chrome.runtime.sendMessage({ type: 'launchGoogleAuth' });
-        if (result?.success) {
-          if (signinContainer) signinContainer.style.display = 'none';
-          if (mainContainer) mainContainer.style.display = '';
-          // Continue with normal init
-          await loadSettings();
-          setupEventListeners();
-          await updateOpenRouterStatus();
-          await updateRateLimitAlert();
-          await updateLocalModelStatus();
-          setupLocalModelListeners();
-          setupStorageListener();
-        }
-      })().catch(err => console.error('[Popup] Google sign-in failed:', err)); });
-      return;
+        // Wire up sign-in button
+        popupGoogleSignIn?.addEventListener('click', () => { (async () => {
+          const result: { success?: boolean } = await chrome.runtime.sendMessage({ type: 'launchGoogleAuth' });
+          if (result?.success) {
+            if (signinContainer) signinContainer.style.display = 'none';
+            if (mainContainer) mainContainer.style.display = '';
+            // Continue with normal init
+            await loadSettings();
+            setupEventListeners();
+            await updateOpenRouterStatus();
+            await updateRateLimitAlert();
+            await updateLocalModelStatus();
+            setupLocalModelListeners();
+            setupStorageListener();
+          }
+        })().catch(err => console.error('[Popup] Google sign-in failed:', err)); });
+        return;
+      }
+    } catch {
+      // If we can't check auth, show main UI anyway
     }
-  } catch {
-    // If we can't check auth, show main UI anyway
   }
 
   await loadSettings();
@@ -218,7 +222,7 @@ async function loadSettings() {
   updateApiProviderStates(data);
 
   // Model selection
-  renderModelDropdown(data.customModels || [], data.selectedModel || 'imbue');
+  renderModelDropdown(data.customModels || [], data.selectedModel || DEFAULT_MODEL);
 
   // Update local model section visibility
   updateLocalModelSectionVisibility();
@@ -305,11 +309,11 @@ function updateApiProviderStates(data: Partial<StorageSchema>) {
     // For local models, check if local models are enabled
     if (api === 'local') {
       if (!dropdownState.localModelsEnabled) {
-        selectModel('imbue').catch(err => console.error('[Popup] selectModel failed:', err));
+        selectModel(DEFAULT_MODEL).catch(err => console.error('[Popup] selectModel failed:', err));
       }
     } else if (!dropdownState.authenticatedApis[api]) {
-      // Provider no longer authenticated, reset to Imbue
-      selectModel('imbue').catch(err => console.error('[Popup] selectModel failed:', err));
+      // Provider no longer authenticated, reset to default
+      selectModel(DEFAULT_MODEL).catch(err => console.error('[Popup] selectModel failed:', err));
     }
   }
 }
@@ -333,7 +337,7 @@ function setupEventListeners() {
     await setStorage({ openaiApiKey: key });
     const data = await getStorage(['openrouterApiKey', 'openaiApiKey', 'openaiApiBase', 'geminiApiKey', 'anthropicApiKey', 'customModels', 'selectedModel', 'authErrorApis']);
     updateApiProviderStates(data);
-    renderModelDropdown(data.customModels || [], data.selectedModel || 'imbue');
+    renderModelDropdown(data.customModels || [], data.selectedModel || DEFAULT_MODEL);
   })().catch(err => console.error('[Popup] openaiApiKey change failed:', err)); });
 
   // OpenAI API base URL
@@ -405,7 +409,7 @@ function setupEventListeners() {
           const data = await getStorage(['openrouterApiKey', 'openaiApiKey', 'geminiApiKey', 'anthropicApiKey', 'customModels', 'selectedModel', 'authErrorApis']);
           updateApiProviderStates(data);
           updateAnthropicEnabledUI(true);
-          renderModelDropdown(data.customModels || [], data.selectedModel || 'imbue');
+          renderModelDropdown(data.customModels || [], data.selectedModel || DEFAULT_MODEL);
         } else {
           errorEl.textContent = msg;
           errorEl.style.display = 'block';
@@ -423,7 +427,7 @@ function setupEventListeners() {
         const data = await getStorage(['openrouterApiKey', 'openaiApiKey', 'geminiApiKey', 'anthropicApiKey', 'customModels', 'selectedModel', 'authErrorApis']);
         updateApiProviderStates(data);
         updateAnthropicEnabledUI(true);
-        renderModelDropdown(data.customModels || [], data.selectedModel || 'imbue');
+        renderModelDropdown(data.customModels || [], data.selectedModel || DEFAULT_MODEL);
       }
     } catch (err) {
       console.error('[Anthropic] Network error during verification:', err);
@@ -443,7 +447,7 @@ function setupEventListeners() {
     updateAnthropicEnabledUI(false);
     const data = await getStorage(['openrouterApiKey', 'openaiApiKey', 'geminiApiKey', 'anthropicApiKey', 'customModels', 'selectedModel', 'authErrorApis']);
     updateApiProviderStates(data);
-    renderModelDropdown(data.customModels || [], data.selectedModel || 'imbue');
+    renderModelDropdown(data.customModels || [], data.selectedModel || DEFAULT_MODEL);
   })().catch(err => console.error('[Popup] Anthropic disable failed:', err)); });
 
   // Gemini API key
@@ -452,7 +456,7 @@ function setupEventListeners() {
     await setStorage({ geminiApiKey: key });
     const data = await getStorage(['openrouterApiKey', 'openaiApiKey', 'geminiApiKey', 'anthropicApiKey', 'customModels', 'selectedModel', 'authErrorApis']);
     updateApiProviderStates(data);
-    renderModelDropdown(data.customModels || [], data.selectedModel || 'imbue');
+    renderModelDropdown(data.customModels || [], data.selectedModel || DEFAULT_MODEL);
   })().catch(err => console.error('[Popup] geminiApiKey change failed:', err)); });
 
   // OpenRouter sign in
@@ -474,7 +478,7 @@ function setupEventListeners() {
 
     // Re-render dropdown to show/hide local models
     const data = await getStorage(['customModels', 'selectedModel']);
-    renderModelDropdown(data.customModels || [], data.selectedModel || 'imbue');
+    renderModelDropdown(data.customModels || [], data.selectedModel || DEFAULT_MODEL);
 
     // Update local model section visibility
     updateLocalModelSectionVisibility();
@@ -495,7 +499,7 @@ interface DropdownState {
 const dropdownState: DropdownState = {
   isOpen: false,
   customModels: [],
-  selectedModel: 'imbue',
+  selectedModel: DEFAULT_MODEL,
   localModelsEnabled: false,
   authenticatedApis: {
     openrouter: false,
@@ -585,10 +589,10 @@ async function removeModel(modelKey: string, e: Event) {
   );
   dropdownState.customModels = newModels;
 
-  // If we're removing the currently selected model, switch to imbue
+  // If we're removing the currently selected model, switch to default
   if (dropdownState.selectedModel === modelKey) {
-    dropdownState.selectedModel = 'imbue';
-    await setStorage({ customModels: newModels, selectedModel: 'imbue' });
+    dropdownState.selectedModel = DEFAULT_MODEL;
+    await setStorage({ customModels: newModels, selectedModel: DEFAULT_MODEL });
     // Clear cache since model changed
     await chrome.runtime.sendMessage({ type: 'clearCache' });
   } else {
@@ -615,7 +619,9 @@ function renderModelDropdown(customModels: ModelDef[], selectedModel: string) {
 
   // Update selected display text
   const selectedText = document.querySelector('.model-dropdown-text')!;
-  if (selectedModel === 'imbue') {
+  if (!selectedModel) {
+    selectedText.textContent = 'Select a model';
+  } else if (selectedModel === 'imbue') {
     selectedText.textContent = 'Imbue (Default)';
   } else {
     // Parse model key (format: api:modelName)
@@ -641,12 +647,14 @@ function renderModelDropdown(customModels: ModelDef[], selectedModel: string) {
   const menu = document.getElementById('modelDropdownMenu')!;
   menu.innerHTML = '';
 
-  // Add Imbue option (direct select, no submenu)
-  const imbueItem = document.createElement('div');
-  imbueItem.className = 'model-dropdown-item' + (selectedModel === 'imbue' ? ' selected' : '');
-  imbueItem.innerHTML = '<span class="model-dropdown-item-text">Imbue (Default) <span class="free-badge">free</span></span>';
-  imbueItem.addEventListener('click', asyncHandler(() => selectModel('imbue')));
-  menu.appendChild(imbueItem);
+  // Add Imbue option (direct select, no submenu) — only when Imbue backend is configured
+  if (process.env.HAS_IMBUE_BACKEND === 'true') {
+    const imbueItem = document.createElement('div');
+    imbueItem.className = 'model-dropdown-item' + (selectedModel === 'imbue' ? ' selected' : '');
+    imbueItem.innerHTML = '<span class="model-dropdown-item-text">Imbue (Default) <span class="free-badge">free</span></span>';
+    imbueItem.addEventListener('click', asyncHandler(() => selectModel('imbue')));
+    menu.appendChild(imbueItem);
+  }
 
   // Add local models (only show if enabled and WebGPU supported)
   if (dropdownState.localModelsEnabled && webgpuSupported && !isIOSDevice && PREDEFINED_MODELS.local) {
@@ -1108,13 +1116,13 @@ async function exchangeCodeForKey(code: string, codeVerifier: string) {
   // Check if this is the first time authenticating OpenRouter
   const storageData = await getStorage(['openrouterApiKey', 'selectedModel']);
   const isFirstAuth = !storageData.openrouterApiKey;
-  const currentModel = storageData.selectedModel || 'imbue';
+  const currentModel = storageData.selectedModel || DEFAULT_MODEL;
 
   // Store the API key
   await setStorage({ openrouterApiKey: data.key });
 
-  // If first authentication and user is on default Imbue model, auto-switch to Nemotron
-  if (isFirstAuth && currentModel === 'imbue') {
+  // If first authentication and user is on default/no model, auto-switch to Nemotron
+  if (isFirstAuth && (currentModel === 'imbue' || !currentModel)) {
     await setStorage({ selectedModel: 'openrouter:nvidia/nemotron-nano-12b-v2-vl:free' });
   }
 }
@@ -1137,7 +1145,7 @@ async function updateOpenRouterStatus() {
 
   // Update all API provider states
   updateApiProviderStates(data);
-  renderModelDropdown(data.customModels || [], data.selectedModel || 'imbue');
+  renderModelDropdown(data.customModels || [], data.selectedModel || DEFAULT_MODEL);
 }
 
 // Sign out from OpenRouter
@@ -1475,5 +1483,5 @@ function setupLocalModelListeners() {
 // Refresh model dropdown with current local model statuses
 async function refreshModelDropdownWithLocal() {
   const data = await getStorage(['customModels', 'selectedModel']);
-  renderModelDropdown(data.customModels || [], data.selectedModel || 'imbue');
+  renderModelDropdown(data.customModels || [], data.selectedModel || DEFAULT_MODEL);
 }

--- a/Bouncer/src/shared/models.ts
+++ b/Bouncer/src/shared/models.ts
@@ -74,6 +74,10 @@ export const PREDEFINED_MODELS: PredefinedModelsMap = {
   ]
 };
 
+// Default model: 'imbue' when the Imbue backend is configured, empty string otherwise.
+// Imported by background, popup, and content scripts to avoid repeating the conditional.
+export const DEFAULT_MODEL = process.env.HAS_IMBUE_BACKEND === 'true' ? 'imbue' : '';
+
 export const API_DISPLAY_NAMES: Record<string, string> = {
   openai: 'OpenAI',
   gemini: 'Gemini',

--- a/Bouncer/tests/background/pipeline.test.ts
+++ b/Bouncer/tests/background/pipeline.test.ts
@@ -286,3 +286,8 @@ describe('processBatch re-queue on inference queue cleared', () => {
     expect(isKeyPending(TAB_ID, 'new_key')).toBe(true);
   });
 });
+
+// Note: The no-model-configured path (empty selectedModel -> no_api_key error) is only
+// reachable in no-Imbue builds where DEFAULT_MODEL is ''. Since DEFAULT_MODEL is computed
+// at module load time from the build-time constant HAS_IMBUE_BACKEND, it can't be varied
+// per test. Testing that path would require a separate build/test configuration.

--- a/Bouncer/tests/setup.ts
+++ b/Bouncer/tests/setup.ts
@@ -3,6 +3,7 @@ globalThis.process = globalThis.process || {};
 globalThis.process.env = globalThis.process.env || {};
 process.env.BOUNCER_ENV = process.env.BOUNCER_ENV || 'test';
 process.env.IMBUE_WS_URL = process.env.IMBUE_WS_URL || 'wss://test.aibutler.api.imbue.com';
+process.env.HAS_IMBUE_BACKEND = process.env.HAS_IMBUE_BACKEND || 'true';
 
 // Global mocks for Chrome extension APIs
 globalThis.chrome = {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bouncer
 
 <p align="center">
-  <img src="appstore_assets/logo.png" alt="Bouncer" width="200" />
+  <img src="Bouncer/icons/b-bouncer-2x_big.png" alt="Bouncer" width="200" />
 </p>
 
 **Heal your feed.** Bouncer is a browser extension that uses AI to filter unwanted posts from your Twitter/X feed. Define filter topics in plain language — "crypto", "engagement bait", "rage politics" — and Bouncer classifies and hides matching posts in real time.


### PR DESCRIPTION
## Summary
- Build script detects whether `.env` has valid Imbue/Firebase credentials; when absent, an esbuild plugin swaps `auth.ts` and `ws-manager.ts` with no-op stubs, completely excluding the Firebase SDK from the bundle
- `HAS_IMBUE_BACKEND` define flag gates Imbue-specific logic in the pipeline, popup, and content scripts
- Without Imbue: no Google sign-in gate, no Imbue model option, "Select a model" prompt in dropdown, toast warning when no model is configured, OpenRouter auto-switch on first auth

## Test plan
- [x] `npm run build` succeeds with Imbue `.env` present (Firebase in bundle: 122 references)
- [x] `npm run build` succeeds without `.env` files (Firebase in bundle: 0 references)
- [x] `npm run lint` passes
- [x] `npm run test` passes (199/199 tests)
- [ ] Manual: load no-Imbue build in Chrome, verify filter box appears without sign-in gate
- [ ] Manual: verify dropdown shows "Select a model" with no Imbue option
- [ ] Manual: verify adding a filter phrase shows "No model configured" toast
- [ ] Manual: verify configuring OpenRouter auto-switches to Nemotron