### PR TITLE
Add Pornhub platform support

### DIFF
--- a/Bouncer/adapters/pornhub/PornhubAdapter.ts
+++ b/Bouncer/adapters/pornhub/PornhubAdapter.ts
@@ -1,0 +1,92 @@
+import type { PlatformAdapter, PlatformSelectors, PostContent } from '../../src/types';
+
+window.BouncerAdapter = class PornhubAdapter implements PlatformAdapter {
+  siteId = 'pornhub' as const;
+
+  selectors: PlatformSelectors = {
+    post: 'li.pcVideoListItem, li.videoblock, div.videoBox',
+    sidebar: '#rightSide, .sidebar',
+    sidebarContent: '#rightSide > div, .sidebar > div',
+    primaryColumn: '#main-container, .nf-videos',
+    nav: '#headerWrapper',
+    bottomBar: '#footer',
+    mutations: '.title a',
+    textContent: '.title a',
+  };
+
+  extractPostContent(article: HTMLElement): PostContent {
+    const titleEl = article.querySelector('.title a') as HTMLAnchorElement | null;
+    const title = titleEl?.textContent?.trim() || titleEl?.getAttribute('title') || '';
+    const uploader = article.querySelector('.usernameWrap a')?.textContent?.trim() || '';
+    const views = article.querySelector('.views, var.views')?.textContent?.trim() || '';
+    const duration = article.querySelector('.duration, var.duration')?.textContent?.trim() || '';
+    const tagEls = article.querySelectorAll('.tags a');
+    const tags = Array.from(tagEls).map(t => t.textContent?.trim()).filter(Boolean).join(', ');
+    const parts = [title];
+    if (tags) parts.push(`Tags: ${tags}`);
+    if (duration) parts.push(duration);
+    if (views) parts.push(views);
+    const thumbEl = article.querySelector('img.thumb, img.js-videoThumb, .phimage img') as HTMLImageElement | null;
+    const thumbUrl = thumbEl?.getAttribute('data-thumb_url') || thumbEl?.src || '';
+    const imageUrls = thumbUrl && !thumbUrl.startsWith('data:') ? [thumbUrl] : [];
+    return {
+      text: parts.join(' | '),
+      author: uploader,
+      handle: uploader,
+      avatarUrl: null,
+      timeText: null,
+      textHtml: titleEl?.innerHTML || title,
+      quote: null,
+      postUrl: titleEl?.href || null,
+      imageUrls,
+      hasMediaContainer: imageUrls.length > 0,
+    };
+  }
+
+  shouldProcessCurrentPage(): boolean {
+    const path = window.location.pathname;
+    return path === '/' || path.startsWith('/categories') || path.startsWith('/video') ||
+      path.startsWith('/search') || path.startsWith('/recommended') ||
+      path.startsWith('/pornstar') || path.startsWith('/channels') || path.startsWith('/model');
+  }
+
+  isMainPost(): boolean { return false; }
+
+  getPostUrl(article: HTMLElement): string | null {
+    return (article.querySelector('.title a, a[href*="viewkey"]') as HTMLAnchorElement | null)?.href || null;
+  }
+
+  getPostContentKey(article: HTMLElement): string {
+    return article.getAttribute('data-video-vkey') || this.getPostUrl(article) ||
+      article.querySelector('.title a')?.textContent?.substring(0, 200) || '';
+  }
+
+  getPostContainer(article: HTMLElement): HTMLElement { return article; }
+
+  hidePost(article: HTMLElement): void {
+    article.style.display = 'none';
+    article.dataset.filteredByExtension = 'true';
+  }
+
+  getThemeMode(): 'light' | 'dim' | 'dark' { return 'dark'; }
+
+  async extractPostContentFromStore(article: HTMLElement): Promise<PostContent | null> {
+    return this.extractPostContent(article);
+  }
+
+  cleanupFilteredPostHtml(el: HTMLElement): void {
+    el.style.display = '';
+    el.removeAttribute('data-filtered-by-extension');
+  }
+
+  getShareButton(): HTMLElement | null { return null; }
+
+  insertActionButton(article: HTMLElement, button: HTMLElement): void {
+    const info = article.querySelector('.thumbnail-info-wrapper');
+    if (info) info.appendChild(button);
+  }
+
+  getSearchForm(): HTMLElement | null {
+    return document.querySelector('#search-form, form[action*="search"]');
+  }
+};

--- a/Bouncer/adapters/pornhub/pornhub.css
+++ b/Bouncer/adapters/pornhub/pornhub.css
@@ -1,0 +1,1 @@
+body.site-pornhub .post-verification-bar { opacity: 0.7; }

--- a/Bouncer/build.js
+++ b/Bouncer/build.js
@@ -78,8 +78,10 @@ const imbueStubPlugin = {
   },
 };
 
-const adapterTsPath = path.join(__dirname, 'adapters/twitter/TwitterAdapter.ts');
-const hasAdapterTs = fs.existsSync(adapterTsPath);
+const adapterEntries = [
+  ['adapters/twitter/TwitterAdapter.ts', 'dist/TwitterAdapter.js'],
+  ['adapters/pornhub/PornhubAdapter.ts', 'dist/PornhubAdapter.js'],
+];
 
 async function build() {
   console.log(hasImbue
@@ -107,17 +109,18 @@ async function build() {
 
   const contexts = [ctx];
 
-  // Type-strip the adapter (unbundled, standalone content script)
-  if (hasAdapterTs) {
-    const adapterCtx = await esbuild.context({
-      entryPoints: [adapterTsPath],
-      outfile: path.join(__dirname, 'dist/TwitterAdapter.js'),
-      bundle: false,
-      format: 'iife',
-      platform: 'browser',
-      target: 'es2020',
-    });
-    contexts.push(adapterCtx);
+  for (const [src, out] of adapterEntries) {
+    const tsPath = path.join(__dirname, src);
+    if (fs.existsSync(tsPath)) {
+      contexts.push(await esbuild.context({
+        entryPoints: [tsPath],
+        outfile: path.join(__dirname, out),
+        bundle: false,
+        format: 'iife',
+        platform: 'browser',
+        target: 'es2020',
+      }));
+    }
   }
 
   if (isWatch) {
@@ -126,8 +129,9 @@ async function build() {
   } else {
     await Promise.all(contexts.map(c => c.rebuild()));
     await Promise.all(contexts.map(c => c.dispose()));
+    const builtAdapters = adapterEntries.filter(([src]) => fs.existsSync(path.join(__dirname, src))).map(([, out]) => out);
     console.log(`Build complete (env: ${env}): dist/background.js, dist/popup.js, dist/content.js` +
-      (hasAdapterTs ? ', dist/TwitterAdapter.js' : ''));
+      (builtAdapters.length ? ', ' + builtAdapters.join(', ') : ''));
   }
 }
 

--- a/Bouncer/manifest.json
+++ b/Bouncer/manifest.json
@@ -14,6 +14,7 @@
   "host_permissions": [
     "https://twitter.com/*",
     "https://x.com/*",
+    "https://*.pornhub.com/*",
     "https://api.anthropic.com/*",
     "https://openrouter.ai/*",
     "https://api.openai.com/*",
@@ -46,6 +47,21 @@
       "css": [
         "content.css",
         "adapters/twitter/twitter.css"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": [
+        "https://*.pornhub.com/*"
+      ],
+      "js": [
+        "dompurify.js",
+        "dist/PornhubAdapter.js",
+        "dist/content.js"
+      ],
+      "css": [
+        "content.css",
+        "adapters/pornhub/pornhub.css"
       ],
       "run_at": "document_idle"
     }

--- a/Bouncer/src/background/index.ts
+++ b/Bouncer/src/background/index.ts
@@ -96,7 +96,7 @@ if (chrome.runtime.setUninstallURL) {
     // Without this, activeTabId stays null until a content script sends a message,
     // leaving the per-tab queue idle even if posts are already queued.
     try {
-      const tabs = await chrome.tabs.query({ url: ['*://twitter.com/*', '*://x.com/*'] });
+      const tabs = await chrome.tabs.query({ url: ['*://twitter.com/*', '*://x.com/*', '*://*.pornhub.com/*'] });
       for (const tab of tabs) {
         try {
           await chrome.tabs.sendMessage(tab.id!, { type: 'ping' });

--- a/Bouncer/src/types.ts
+++ b/Bouncer/src/types.ts
@@ -1,7 +1,7 @@
 // ==================== Site IDs ====================
 
 /** Known platform adapter identifiers. Add new entries when adding adapters. */
-export type SiteId = 'twitter';
+export type SiteId = 'twitter' | 'pornhub';
 
 // ==================== Core Evaluation ====================
 


### PR DESCRIPTION
## Summary
- Adds a `PornhubAdapter` implementing the `PlatformAdapter` interface to enable Bouncer's LLM text categorization on Pornhub
- Extracts video title, uploader, tags, duration, and thumbnail from video listing cards (`.pcVideoListItem`, `.videoblock`, `.videoBox`)
- Active on homepage, categories, search, recommended, pornstar, channel, and model pages
- Registers Pornhub in the manifest (`content_scripts`, `host_permissions`), build system, and background tab detection
- Refactors adapter build in `build.js` to a data-driven loop for cleaner multi-adapter support

## Changes
- `Bouncer/src/types.ts` — add `'pornhub'` to `SiteId`
- `Bouncer/adapters/pornhub/PornhubAdapter.ts` — new adapter
- `Bouncer/adapters/pornhub/pornhub.css` — minimal site-specific styles
- `Bouncer/manifest.json` — Pornhub content script + host permission
- `Bouncer/build.js` — adapter build loop
- `Bouncer/src/background/index.ts` — tab detection URL pattern