### PR TITLE
Use structured JSON output for local model classification

### DIFF
--- a/Bouncer/src/background/local-model.ts
+++ b/Bouncer/src/background/local-model.ts
@@ -81,7 +81,7 @@ export function parseLocalModelResponse(rawResponse: string | null): { shouldHid
     const parsed = JSON.parse(rawResponse);
     if (typeof parsed === 'object' && parsed !== null && 'reasoning' in parsed) {
       const match = parsed.match;
-      const shouldHide = typeof match === 'string' && match.length > 0;
+      const shouldHide = typeof match === 'string' && match.length > 0 && match !== 'null';
       const reasoning = shouldHide
         ? `${parsed.reasoning} (Matched: ${match})`
         : String(parsed.reasoning);
@@ -353,9 +353,10 @@ export class LocalEngine {
   async generate(
     messages: ChatMessage[],
     maxTokens: number,
-    { priority = 0, temperature, onStart }: { priority?: number; temperature?: number; onStart?: () => void } = {}
+    { priority = 0, temperature, onStart, responseFormat }: { priority?: number; temperature?: number; onStart?: () => void; responseFormat?: Record<string, unknown> } = {}
   ): Promise<string> {
-    const requestOpts: Record<string, unknown> = { messages, max_tokens: maxTokens, response_format: CLASSIFICATION_RESPONSE_FORMAT };
+    const requestOpts: Record<string, unknown> = { messages, max_tokens: maxTokens };
+    if (responseFormat) requestOpts.response_format = responseFormat;
     if (temperature !== undefined) requestOpts.temperature = temperature;
     const request = buildInferenceRequest(this._modelConfig || ({} as Record<string, never>), requestOpts);
 
@@ -703,7 +704,7 @@ export async function callLocalInference(
 
   let rawResponse: string;
   try {
-    rawResponse = await localEngine.generate(messages, 40, { priority, onStart });
+    rawResponse = await localEngine.generate(messages, 40, { priority, onStart, responseFormat: CLASSIFICATION_RESPONSE_FORMAT });
   } catch (imgError) {
     if ((imgError as Error).message === 'Inference preempted') throw imgError;
     if (useImages) {
@@ -713,7 +714,7 @@ export async function callLocalInference(
         { role: "system", content: LOCAL_SYSTEM_PROMPT },
         { role: "user", content: textOnlyContent }
       ];
-      rawResponse = await localEngine.generate(textMessages, 40, { priority, onStart });
+      rawResponse = await localEngine.generate(textMessages, 40, { priority, onStart, responseFormat: CLASSIFICATION_RESPONSE_FORMAT });
     } else {
       throw imgError;
     }

--- a/Bouncer/src/background/local-model.ts
+++ b/Bouncer/src/background/local-model.ts
@@ -26,6 +26,19 @@ const DOWNLOAD_RETRY_DELAY_MS = 2000;
 // Keys that belong on the ModelRecord (appConfig), not chatOpts.
 const MODEL_RECORD_KEYS = new Set(['model', 'model_lib', 'model_type']);
 
+/** JSON schema for structured classification output from local models. */
+const CLASSIFICATION_RESPONSE_FORMAT = {
+  type: 'json_object' as const,
+  schema: JSON.stringify({
+    type: 'object',
+    properties: {
+      reasoning: { type: 'string' },
+      match: { type: ['string', 'null'] },
+    },
+    required: ['reasoning', 'match'],
+  }),
+};
+
 // ==================== Pure helpers ====================
 
 // Build both the appConfig (ModelRecord for CreateMLCEngine) and chatOpts
@@ -342,7 +355,7 @@ export class LocalEngine {
     maxTokens: number,
     { priority = 0, temperature, onStart }: { priority?: number; temperature?: number; onStart?: () => void } = {}
   ): Promise<string> {
-    const requestOpts: Record<string, unknown> = { messages, max_tokens: maxTokens };
+    const requestOpts: Record<string, unknown> = { messages, max_tokens: maxTokens, response_format: CLASSIFICATION_RESPONSE_FORMAT };
     if (temperature !== undefined) requestOpts.temperature = temperature;
     const request = buildInferenceRequest(this._modelConfig || ({} as Record<string, never>), requestOpts);
 

--- a/Bouncer/src/background/local-model.ts
+++ b/Bouncer/src/background/local-model.ts
@@ -63,6 +63,22 @@ export function parseLocalModelResponse(rawResponse: string | null): { shouldHid
     return { shouldHide: false, reasoning: 'Empty model response — model returned no output' };
   }
 
+  // Try JSON structured output first
+  try {
+    const parsed = JSON.parse(rawResponse);
+    if (typeof parsed === 'object' && parsed !== null && 'reasoning' in parsed) {
+      const match = parsed.match;
+      const shouldHide = typeof match === 'string' && match.length > 0;
+      const reasoning = shouldHide
+        ? `${parsed.reasoning} (Matched: ${match})`
+        : String(parsed.reasoning);
+      return { shouldHide, reasoning };
+    }
+  } catch {
+    // Not JSON — fall through to regex parsing
+  }
+
+  // Fallback: freeform text parsing (backward compatibility)
   let reasoning = rawResponse;
   let shouldHide = false;
 

--- a/Bouncer/src/shared/prompts.ts
+++ b/Bouncer/src/shared/prompts.ts
@@ -3,25 +3,9 @@
 import type { ChatMessage, EvaluationPostData } from '../types';
 
 // System prompt for local models processing one post at a time
-export const LOCAL_SYSTEM_PROMPT = `You filter posts. Write 10-15 words identifying what the post is about, then state if it matches a filter category.
+export const LOCAL_SYSTEM_PROMPT = `You filter posts. Classify whether a post matches any of the given filter categories.
 
-Example outputs (NOTE: you may not be filtering on these categories!):
-
-<example>
-<filter_categories>sports</filter_categories>
-<post>The Lakers won last night against the Bucks!</post>
-Post about NBA basketball game results, which is sports content. Matches sports.
-</example>
-
-<example>
-<filter_categories>politics</filter_categories>
-<post>I love cooking dinner each night with my husband</post>
-Post about making dinner at home, which is Food/lifestyle content, not politics content. No match.
-</example>
-
-You will be provided with a post (<post>) and a list of filter categories (<filter_categories>).
-Assess whether the topic of the post relates to any of the topics in the filter categories list.
-Your reasoning must be AT MOST 15 words, and MUST end with a statement of "Matches <topic>" or "No match".
+Respond with JSON: {"reasoning": "<10-15 words about what the post is about>", "match": "<matched category or null>"}
 
 Be precise in your judgment; only match posts that clearly and directly relate to the filter categories.`;
 

--- a/Bouncer/tests/background/local-model.test.ts
+++ b/Bouncer/tests/background/local-model.test.ts
@@ -677,6 +677,41 @@ describe('parseLocalModelResponse', () => {
   });
 });
 
+describe('parseLocalModelResponse — structured JSON output', () => {
+  it('parses a JSON match response', () => {
+    const raw = '{"reasoning":"NBA game results, sports content","match":"sports"}';
+    const result = parseLocalModelResponse(raw);
+    expect(result.shouldHide).toBe(true);
+    expect(result.reasoning).toContain('sports');
+  });
+
+  it('parses a JSON no-match response', () => {
+    const raw = '{"reasoning":"Cooking dinner at home, lifestyle content","match":null}';
+    const result = parseLocalModelResponse(raw);
+    expect(result.shouldHide).toBe(false);
+    expect(result.reasoning).toContain('Cooking');
+  });
+
+  it('parses JSON with match as empty string as no-match', () => {
+    const raw = '{"reasoning":"General lifestyle post","match":""}';
+    const result = parseLocalModelResponse(raw);
+    expect(result.shouldHide).toBe(false);
+  });
+
+  it('falls back to regex parsing for non-JSON freeform output', () => {
+    const raw = 'Post about basketball game results. Matches sports.';
+    const result = parseLocalModelResponse(raw);
+    expect(result.shouldHide).toBe(true);
+    expect(result.reasoning).toContain('sports');
+  });
+
+  it('falls back to regex for malformed JSON', () => {
+    const raw = '{"reasoning": broken json Matches politics.';
+    const result = parseLocalModelResponse(raw);
+    expect(result.shouldHide).toBe(true);
+  });
+});
+
 // ==================== LocalEngine.generate / preempt / ensureLoaded / teardown ====================
 
 describe('LocalEngine generate + preempt + lifecycle', () => {

--- a/Bouncer/tests/background/local-model.test.ts
+++ b/Bouncer/tests/background/local-model.test.ts
@@ -710,6 +710,12 @@ describe('parseLocalModelResponse — structured JSON output', () => {
     const result = parseLocalModelResponse(raw);
     expect(result.shouldHide).toBe(true);
   });
+
+  it('treats match:"null" string as no-match', () => {
+    const raw = '{"reasoning":"Not related","match":"null"}';
+    const result = parseLocalModelResponse(raw);
+    expect(result.shouldHide).toBe(false);
+  });
 });
 
 // ==================== LocalEngine.generate / preempt / ensureLoaded / teardown ====================


### PR DESCRIPTION
## Summary

- Use WebLLM's `response_format: { type: 'json_object' }` to force local models to output valid JSON instead of freeform text
- Update `parseLocalModelResponse()` to try JSON parsing first, falling back to the existing regex-based parsing for backward compatibility
- Simplify `LOCAL_SYSTEM_PROMPT` from 21 lines to 4 — format constraints are now enforced by the engine, not by prompt instructions
- Pass `responseFormat` as an optional parameter to `generate()` so non-classification callers (e.g. suggestAnnoyingReasons) still get freeform text

**Problem:** Local model responses are parsed with regex looking for "Matches X" or "No match" in freeform text. When the model phrases things differently, the regex misses and the post silently gets classified as "no match" — a false negative.

**Fix:** Constrained decoding guarantees valid JSON output. The model can only produce `{"reasoning": "...", "match": "..."}`. Zero parsing ambiguity. The vendored WebLLM (0.2.82-custom) already supports `json_object` response format — it just wasn't being used.

## Changes

| File | What |
|------|------|
| `src/background/local-model.ts` | Add `CLASSIFICATION_RESPONSE_FORMAT` constant, make `responseFormat` optional on `generate()`, pass it from `callLocalInference`, guard against `"null"` string match |
| `src/shared/prompts.ts` | Simplify `LOCAL_SYSTEM_PROMPT` (21 lines → 4 lines) |
| `tests/background/local-model.test.ts` | 6 new tests: JSON match, no-match, empty string, "null" string, regex fallback, malformed JSON fallback |

## Test plan

- [x] 6 new tests for JSON parsing + edge cases
- [x] All 205 tests pass (existing regex-based tests still pass via fallback path)
- [x] `response_format` only applied to classification calls, not suggestAnnoyingReasons
- [x] Backward compatible — non-JSON model output still parsed via regex fallback