### PR TITLE
Quote argument-hint values in SKILL.md frontmatter

### DIFF
--- a/.claude/skills/create-html-mock/SKILL.md
+++ b/.claude/skills/create-html-mock/SKILL.md
@@ -2,7 +2,7 @@
 name: create-html-mock
 description: Create HTML mocks for a new feature idea
 disable-model-invocation: true
-argument-hint: [feature description]
+argument-hint: "[feature description]"
 ---
 
 # Create HTML Mock

--- a/.claude/skills/extract-requirements-from-mock/SKILL.md
+++ b/.claude/skills/extract-requirements-from-mock/SKILL.md
@@ -2,7 +2,7 @@
 name: extract-requirements-from-mock
 description: Extract requirements document from HTML mock iteration
 disable-model-invocation: true
-argument-hint: [feature-name]
+argument-hint: "[feature-name]"
 ---
 
 # Extract Requirements from Mock


### PR DESCRIPTION
## Bug

Two SKILL.md files use unquoted square brackets in their `argument-hint:` YAML frontmatter:

- `.claude/skills/create-html-mock/SKILL.md`: `argument-hint: [feature description]`
- `.claude/skills/extract-requirements-from-mock/SKILL.md`: `argument-hint: [feature-name]`

Per YAML 1.2 flow syntax, `[X]` parses as a **sequence (array)**, not a string. Tools that consume this frontmatter and require `argument-hint` to be a string will reject or misrender these skills.

## Impact

GitHub Copilot CLI 1.0.65 requires `argument-hint` to be a string and rejects arrays. There is also a latent equivalent issue tracked for Claude Code in anthropics/claude-code#22161.

## Fix

Quote the values so YAML parses them as strings:

```diff
-argument-hint: [feature description]
+argument-hint: "[feature description]"
```

```diff
-argument-hint: [feature-name]
+argument-hint: "[feature-name]"
```

The rendered hint (`[feature description]`, `[feature-name]`) is unchanged — only the YAML type changes from sequence to string.

The other three SKILL.md files in `.claude/skills/` use `<feature-name>` (angle brackets), which YAML already parses as a string, so they need no change.

## Test plan

- [x] `python3 -c "import yaml; ..."` on both files: `argument-hint` now parses as `str` (`'[feature description]'`, `'[feature-name]'`) instead of `list`.
- [x] Load the skills in GitHub Copilot CLI 1.0.65 and confirm they no longer error on the frontmatter.
- [x] Verify the argument hint still displays as `[feature description]` / `[feature-name]` in tool UIs.
