### PR TITLE
Filter posts on custom feed tabs on x.com/home

### DIFF
--- a/Bouncer/adapters/twitter/TwitterAdapter.ts
+++ b/Bouncer/adapters/twitter/TwitterAdapter.ts
@@ -253,13 +253,14 @@ const BouncerTwitterAdapter = class TwitterAdapter implements PlatformAdapter {
     const tabBar = document.querySelector('[role="tablist"]');
     if (!tabBar) return false;
 
+    // Every tab on the /home tablist renders a tweet timeline — "For you",
+    // "Following", and any pinned custom feeds (Lists/Communities). Accept
+    // whichever tab is selected rather than matching tab names, which would
+    // exclude custom feeds and break on non-English UI languages.
     const tabs = tabBar.querySelectorAll('[role="tab"]');
     for (const tab of tabs) {
-      const tabText = tab.textContent?.toLowerCase() || '';
-      if (tabText.includes('for you') || tabText.includes('following')) {
-        if (tab.getAttribute('aria-selected') === 'true') {
-          return true;
-        }
+      if (tab.getAttribute('aria-selected') === 'true') {
+        return true;
       }
     }
 

--- a/Bouncer/tests/adapter/twitter-adapter.test.ts
+++ b/Bouncer/tests/adapter/twitter-adapter.test.ts
@@ -213,12 +213,21 @@ describe('shouldProcessCurrentPage', () => {
     expect(adapter.shouldProcessCurrentPage()).toBe(true);
   });
 
-  it('returns false on /home with no matching tab selected', () => {
+  it('returns true on /home with a custom feed tab selected', () => {
     setPath('/home');
     addTabList([
       { text: 'For you', selected: false },
       { text: 'Following', selected: false },
-      { text: 'Lists', selected: true },
+      { text: 'AI stuff', selected: true },
+    ]);
+    expect(adapter.shouldProcessCurrentPage()).toBe(true);
+  });
+
+  it('returns false on /home when no tab is selected', () => {
+    setPath('/home');
+    addTabList([
+      { text: 'For you', selected: false },
+      { text: 'Following', selected: false },
     ]);
     expect(adapter.shouldProcessCurrentPage()).toBe(false);
   });


### PR DESCRIPTION
## Summary
- The extension filtered posts only on the built-in "For you" / "Following" tabs: so extension wasn't working pinned custom feeds like "Soccer" or "AI", not sure if this was intentional.
- Now any selected tab on the `/home` tablist passes the check.

## Testing
- Updated unit tests, `npm run lint` and `npm run test` pass (277 tests).
- Verified live in Chrome with the unpacked build: on custom feed tabs (Soccer/Tech)